### PR TITLE
Allow sharing fakeredis state between threads

### DIFF
--- a/src/pyramid_redis/__init__.py
+++ b/src/pyramid_redis/__init__.py
@@ -32,9 +32,12 @@ def includeme(config):
             dsn, max_connections=max_connections)
         redis_client = StrictRedis(connection_pool=pool)
     elif is_type('fakeredis'):
-        from fakeredis import FakeStrictRedis
+        import fakeredis
 
-        redis_client = FakeStrictRedis()
+        server = fakeredis.FakeServer()
+        redis_client = fakeredis.FakeStrictRedis(server=server)
+
+        config.registry.settings["fakeredis_server"] = server
     else:
         logger.error(
             'Redis could not be initialized, DSN %s is not supported!', dsn)


### PR DESCRIPTION
This is needed so that I can assert what a WebTest app (that runs as a WSGI app in a separate thread) is saving to redis.

In my unit test I can do `fakeredis.FakeStrictRedis(server=app.registry.settings['fakeredis_server']` to get access to shared fakeredis state.